### PR TITLE
for manual update of nic.db

### DIFF
--- a/src/info/lamatricexiste/network/Utils/UpdateNicDb.java
+++ b/src/info/lamatricexiste/network/Utils/UpdateNicDb.java
@@ -70,7 +70,7 @@ public class UpdateNicDb extends AsyncTask<Void, String, Void> {
             final Activity d = mActivity.get();
             if (d != null) {
                 d.setProgressBarIndeterminateVisibility(true);
-                progress = ProgressDialog.show(d, "", d.getString(R.string.task_db));
+                progress = ProgressDialog.show(d, "", d.getString(R.string.task_db, Db.DB_NIC));
             }
         }
     }


### PR DESCRIPTION
in the ProgressDialog() for task_db the format string was displayed instead of the filename
